### PR TITLE
[docs] community discussions change

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -25,7 +25,7 @@ LOCAL_MODULE_TAGS := eng
 
 LOCAL_CFLAGS := \
 	-DPACKAGE=\"tayga\" \
-	-DPACKAGE_BUGREPORT=\"openthread-users@googlegroups.com\" \
+	-DPACKAGE_BUGREPORT=\"https://github.com/openthread/tayga/issues\" \
 	-DPACKAGE_NAME=\"tayga\" \
 	-DPACKAGE_STRING=\"tayga\ 0.9.2\" \
 	-DPACKAGE_TARNAME=\"tayga\" \


### PR DESCRIPTION
Replace link to openthread-users Google Group with link to GitHub OpenThread Discussions, clarify issue reporting links.